### PR TITLE
[enhance] Use @babel/runtime with es builds to reduce bundle size

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -5,6 +5,16 @@ const cjs = BABEL_ENV === 'cjs' || NODE_ENV === 'test';
 module.exports = {
   presets: [['@babel/preset-env', { loose: true }]],
   plugins: [
+    [
+      require('@babel/plugin-transform-runtime').default,
+      {
+        corejs: false,
+        helpers: true,
+        regenerator: true,
+        useESModules: !cjs,
+        version: '7.5.5'
+      }
+    ],
     // cjs && 'transform-es2015-modules-commonjs',
     '@babel/plugin-proposal-object-rest-spread',
     ['@babel/plugin-proposal-class-properties', { loose: true }]

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@babel/core": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+    "@babel/plugin-transform-runtime": "^7.5.5",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-flow": "^7.0.0",
     "babel-core": "^7.0.0-bridge.0",
@@ -81,5 +82,7 @@
     "rollup-plugin-terser": "^5.0.0",
     "typescript": "^3.4.5"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@babel/runtime": "^7.5.5"
+  }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,5 +17,5 @@ export default {
     { file: `${destBase}.amd${destExtension}`, format: 'amd', name },
     { file: `${destBase}.browser${destExtension}`, format: 'iife', name }
   ],
-  plugins: [babel({}), isProduction && terser(), filesize()].filter(Boolean)
+  plugins: [babel({ runtimeHelpers: true }), isProduction && terser(), filesize()].filter(Boolean)
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -520,6 +520,16 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-runtime@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.5.5.tgz#a6331afbfc59189d2135b2e09474457a8e3d28bc"
+  integrity sha512-6Xmeidsun5rkwnGfMOp6/z9nSzWpHFNVr2Jx7kwoq4mVatQfQx5S56drBgEHF+XQbKOdIaOiMIINvp/kAwMN+w==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz#6333aee2f8d6ee7e28615457298934a3b46198f0"
@@ -632,6 +642,13 @@
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
   integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
+"@babel/runtime@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
+  integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
   dependencies:
     regenerator-runtime "^0.13.2"
 
@@ -4570,6 +4587,13 @@ resolve@^1.10.0, resolve@^1.3.2:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.0.tgz#4014870ba296176b86343d50b60f3b50609ce232"
   integrity sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.8.1:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
+  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem
Applications using webpack or other libraries using rollup can't take full advantage of es modules when the babel runtime helpers are just copied to every file. Including this doesn't change a thing about the non-es bundles but potentially saves great bundle sizes.

# Solution

This does add @babel/runtime as a dependency to ensure it's on the node path in case they are using es modules. For non-es builds it will simply be ignored so no problem. Most of the time if they are also using @babel/runtime the packager will hoist them to the same version if they can match. Worst case scenario is there are two versions which degrades bundle size to where it was previously.

# TODO

- [ ] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [x] Update relevant documentation
