### PR TITLE
[enhance] Allow schemas to have extraneous attributes that are simply ignored 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,38 +4,42 @@ declare namespace schema {
   export type MergeFunction = (entityA: any, entityB: any) => any;
 
   export class Array<T = any> {
-    constructor(definition: Schema<T>, schemaAttribute?: string | SchemaFunction)
-    define(definition: Schema): void
+    constructor(definition: Schema<T>, schemaAttribute?: string | SchemaFunction);
+    define(definition: Schema): void;
   }
 
   export interface EntityOptions<T = any> {
-    idAttribute?: string | SchemaFunction
-    mergeStrategy?: MergeFunction
-    processStrategy?: StrategyFunction<T>
+    idAttribute?: string | SchemaFunction;
+    mergeStrategy?: MergeFunction;
+    processStrategy?: StrategyFunction<T>;
   }
 
   export class Entity<T = any> {
-    constructor(key: string | symbol, definition?: Schema, options?: EntityOptions<T>)
-    define(definition: Schema): void
-    key: string
-    getId: SchemaFunction
-    _processStrategy: StrategyFunction<T>
+    constructor(key: string | symbol, definition?: Schema, options?: EntityOptions<T>);
+    define(definition: Schema): void;
+    key: string;
+    getId: SchemaFunction;
+    _processStrategy: StrategyFunction<T>;
   }
 
   export class Object<T = any> {
-    constructor(definition: {[key: string]: Schema<T>})
-    define(definition: Schema): void
+    constructor(definition: { [key: string]: Schema<T> });
+    define(definition: Schema): void;
   }
 
   export class Union<T = any> {
-    constructor(definition: Schema<T>, schemaAttribute?: string | SchemaFunction)
-    define(definition: Schema): void
+    constructor(definition: Schema<T>, schemaAttribute?: string | SchemaFunction);
+    define(definition: Schema): void;
   }
 
   export class Values<T = any> {
-    constructor(definition: Schema<T>, schemaAttribute?: string | SchemaFunction)
-    define(definition: Schema): void
+    constructor(definition: Schema<T>, schemaAttribute?: string | SchemaFunction);
+    define(definition: Schema): void;
   }
+}
+
+interface SimpleObject {
+  [key: string]: SimpleObject | string | number | boolean | void;
 }
 
 export type Schema<T = any> =
@@ -47,20 +51,16 @@ export type Schema<T = any> =
   | SchemaArray<T>;
 
 export interface SchemaObject<T> {
-  [key: string]: Schema<T>
+  [key: string]: Schema<T> | string | number | boolean | void | SimpleObject;
 }
 
 export interface SchemaArray<T> extends Array<Schema<T>> {}
 
-export type NormalizedSchema<E, R> = { entities: E, result: R };
+export type NormalizedSchema<E, R> = { entities: E; result: R };
 
-export function normalize<T = any, E = { [key:string]: { [key:string]: T }}, R = any>(
+export function normalize<T = any, E = { [key: string]: { [key: string]: T } }, R = any>(
   data: any,
   schema: Schema<T>
 ): NormalizedSchema<E, R>;
 
-export function denormalize(
-  input: any,
-  schema: Schema,
-  entities: any
-): any;
+export function denormalize(input: any, schema: Schema, entities: any): any;

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -35,6 +35,22 @@ Object {
 }
 `;
 
+exports[`denormalize denormalizes schema with extra members 1`] = `
+Object {
+  "data": Array [
+    Object {
+      "id": 1,
+      "type": "foo",
+    },
+    Object {
+      "id": 2,
+      "type": "bar",
+    },
+  ],
+  "extra": "5",
+}
+`;
+
 exports[`denormalize denormalizes with function as idAttribute 1`] = `
 Array [
   Object {
@@ -187,6 +203,30 @@ Object {
     },
   },
   "result": "123",
+}
+`;
+
+exports[`normalize normalizes schema with extra members 1`] = `
+Object {
+  "entities": Object {
+    "tacos": Object {
+      "1": Object {
+        "id": 1,
+        "type": "foo",
+      },
+      "2": Object {
+        "id": 2,
+        "type": "bar",
+      },
+    },
+  },
+  "result": Object {
+    "data": Array [
+      1,
+      2,
+    ],
+    "extra": "five",
+  },
 }
 `;
 

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -18,6 +18,17 @@ describe('normalize', () => {
     expect(normalize([{ id: 1, type: 'foo' }, { id: 2, type: 'bar' }], [mySchema])).toMatchSnapshot();
   });
 
+  test('normalizes schema with extra members', () => {
+    const mySchema = new schema.Entity('tacos');
+
+    expect(
+      normalize(
+        { data: [{ id: 1, type: 'foo' }, { id: 2, type: 'bar' }], extra: 'five' },
+        { data: [mySchema], extra: '' }
+      )
+    ).toMatchSnapshot();
+  });
+
   test('normalizes entities with circular references', () => {
     const user = new schema.Entity('users');
     user.define({
@@ -177,6 +188,17 @@ describe('denormalize', () => {
       }
     };
     expect(denormalize([1, 2], [mySchema], entities)).toMatchSnapshot();
+  });
+
+  test('denormalizes schema with extra members', () => {
+    const mySchema = new schema.Entity('tacos');
+    const entities = {
+      tacos: {
+        1: { id: 1, type: 'foo' },
+        2: { id: 2, type: 'bar' }
+      }
+    };
+    expect(denormalize({ data: [1, 2], extra: '5' }, { data: [mySchema], extra: '' }, entities)).toMatchSnapshot();
   });
 
   test('denormalizes nested entities', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,11 @@ const getUnvisit = (entities) => {
       return unvisitEntity(input, schema, unvisit, getEntity, cache);
     }
 
-    return schema.denormalize(input, unvisit);
+    if (typeof schema.denormalize === 'function') {
+      return schema.denormalize(input, unvisit);
+    }
+
+    return input;
   };
 };
 


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

Sometimes it might be useful to express more in a schema object to be used by other utilities. For instance, having default values for other attributes that are expected in a response but don't turn into entities.

# Solution

Pretty simple: in unvisit we check if schema is really a schema, otherwise we just return input.

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation
