### PR TITLE
[breaking] denormalize() returns a tuple with second arg indicating all entities found

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -41,7 +41,7 @@ const normalizedData = normalize(myData, mySchema);
 }
 ```
 
-## `denormalize(input, schema, entities)`
+## `denormalize(input, schema, entities): [denormalized, foundAllEntities]`
 
 Denormalizes an input based on schema and provided entities from a plain object or Immutable data. The reverse of `normalize`.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,4 +63,4 @@ export function normalize<T = any, E = { [key: string]: { [key: string]: T } }, 
   schema: Schema<T>
 ): NormalizedSchema<E, R>;
 
-export function denormalize(input: any, schema: Schema, entities: any): any;
+export function denormalize(input: any, schema: Schema, entities: any): [any, boolean];

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -27,6 +27,32 @@ Array [
 ]
 `;
 
+exports[`denormalize denormalizes ignoring unfound entities in arrays 1`] = `
+Array [
+  Array [
+    Object {
+      "id": 1,
+      "type": "foo",
+    },
+  ],
+  false,
+]
+`;
+
+exports[`denormalize denormalizes ignoring unfound entities in arrays 2`] = `
+Array [
+  Object {
+    "results": Array [
+      Object {
+        "id": 1,
+        "type": "foo",
+      },
+    ],
+  },
+  false,
+]
+`;
+
 exports[`denormalize denormalizes nested entities 1`] = `
 Array [
   Object {
@@ -88,20 +114,6 @@ Array [
     },
   ],
   true,
-]
-`;
-
-exports[`denormalize denormalizes without entities and ignored undefined in array 1`] = `
-Array [
-  Object {
-    "results": Array [
-      Object {
-        "id": 1,
-        "type": "foo",
-      },
-    ],
-  },
-  false,
 ]
 `;
 

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`denormalize denormalizes arrays with objects inside 1`] = `
+Array [
+  Object {
+    "data": Object {
+      "id": 1,
+      "type": "foo",
+    },
+  },
+  Object {
+    "data": undefined,
+  },
+]
+`;
+
 exports[`denormalize denormalizes entities 1`] = `
 Array [
   Object {
@@ -14,70 +28,105 @@ Array [
 `;
 
 exports[`denormalize denormalizes nested entities 1`] = `
-Object {
-  "author": Object {
-    "id": "8472",
-    "name": "Paul",
-  },
-  "body": "This article is great.",
-  "comments": Array [
-    Object {
-      "comment": "I like it!",
-      "id": "comment-123-4738",
-      "user": Object {
-        "id": "10293",
-        "name": "Jane",
-      },
+Array [
+  Object {
+    "author": Object {
+      "id": "8472",
+      "name": "Paul",
     },
-  ],
-  "id": "123",
-  "title": "A Great Article",
-}
+    "body": "This article is great.",
+    "comments": Array [
+      Object {
+        "comment": "I like it!",
+        "id": "comment-123-4738",
+        "user": Object {
+          "id": "10293",
+          "name": "Jane",
+        },
+      },
+    ],
+    "id": "123",
+    "title": "A Great Article",
+  },
+  true,
+]
 `;
 
 exports[`denormalize denormalizes schema with extra members 1`] = `
-Object {
-  "data": Array [
-    Object {
-      "id": 1,
-      "type": "foo",
-    },
-    Object {
-      "id": 2,
-      "type": "bar",
-    },
-  ],
-  "extra": "5",
-}
+Array [
+  Object {
+    "data": Array [
+      Object {
+        "id": 1,
+        "type": "foo",
+      },
+      Object {
+        "id": 2,
+        "type": "bar",
+      },
+    ],
+    "extra": "5",
+  },
+  true,
+]
 `;
 
 exports[`denormalize denormalizes with function as idAttribute 1`] = `
 Array [
-  Object {
-    "guest": null,
-    "id": "1",
-    "name": "Esther",
-  },
-  Object {
-    "guest": Object {
-      "guest_id": 1,
+  Array [
+    Object {
+      "guest": null,
+      "id": "1",
+      "name": "Esther",
     },
-    "id": "2",
-    "name": "Tom",
+    Object {
+      "guest": Object {
+        "guest_id": 1,
+      },
+      "id": "2",
+      "name": "Tom",
+    },
+  ],
+  true,
+]
+`;
+
+exports[`denormalize denormalizes without entities and ignored undefined in array 1`] = `
+Array [
+  Object {
+    "results": Array [
+      Object {
+        "id": 1,
+        "type": "foo",
+      },
+    ],
   },
+  false,
+]
+`;
+
+exports[`denormalize denormalizes without entities fills undefined 1`] = `
+Array [
+  Object {
+    "data": undefined,
+  },
+  false,
 ]
 `;
 
 exports[`denormalize set to undefined if schema key is not in entities 1`] = `
-Object {
-  "author": undefined,
-  "comments": Array [
-    Object {
-      "user": undefined,
-    },
-  ],
-  "id": "123",
-}
+Array [
+  Object {
+    "author": undefined,
+    "comments": Array [
+      Object {
+        "user": undefined,
+      },
+    ],
+    "id": "123",
+  },
+  false,
+]
 `;
 
 exports[`normalize can use fully custom entity classes 1`] = `

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -201,14 +201,14 @@ describe('denormalize', () => {
     expect(denormalize(1, mySchema, {})).toEqual([undefined, false]);
   });
 
-  test('denormalizes without entities and ignored undefined in array', () => {
+  test('denormalizes ignoring unfound entities in arrays', () => {
     const mySchema = new schema.Entity('tacos');
     const entities = {
       tacos: {
         1: { id: 1, type: 'foo' }
       }
     };
-    expect(denormalize([1, 2], [mySchema], {})).toEqual([[], false]);
+    expect(denormalize([1, 2], [mySchema], entities)).toMatchSnapshot();
     expect(denormalize({ results: [1, 2] }, { results: [mySchema] }, entities)).toMatchSnapshot();
   });
 

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -181,7 +181,7 @@ describe('denormalize', () => {
   });
 
   test('returns the input if undefined', () => {
-    expect(denormalize(undefined, {}, {})).toBeUndefined();
+    expect(denormalize(undefined, {}, {})).toEqual([undefined, false]);
   });
 
   test('denormalizes entities', () => {
@@ -192,7 +192,38 @@ describe('denormalize', () => {
         2: { id: 2, type: 'bar' }
       }
     };
-    expect(denormalize([1, 2], [mySchema], entities)).toMatchSnapshot();
+    expect(denormalize([1, 2], [mySchema], entities)[0]).toMatchSnapshot();
+  });
+
+  test('denormalizes without entities fills undefined', () => {
+    const mySchema = new schema.Entity('tacos');
+    expect(denormalize({ data: 1 }, { data: mySchema }, {})).toMatchSnapshot();
+    expect(denormalize(1, mySchema, {})).toEqual([undefined, false]);
+  });
+
+  test('denormalizes without entities and ignored undefined in array', () => {
+    const mySchema = new schema.Entity('tacos');
+    const entities = {
+      tacos: {
+        1: { id: 1, type: 'foo' }
+      }
+    };
+    expect(denormalize([1, 2], [mySchema], {})).toEqual([[], false]);
+    expect(denormalize({ results: [1, 2] }, { results: [mySchema] }, entities)).toMatchSnapshot();
+  });
+
+  test('denormalizes arrays with objects inside', () => {
+    const mySchema = new schema.Entity('tacos');
+    const entities = {
+      tacos: {
+        1: { id: 1, type: 'foo' }
+      }
+    };
+    expect(denormalize([{ data: 1 }, { data: 2 }], [{ data: mySchema }], {})[0]).toEqual([
+      { data: undefined },
+      { data: undefined }
+    ]);
+    expect(denormalize([{ data: 1 }, { data: 2 }], [{ data: mySchema }], entities)[0]).toMatchSnapshot();
   });
 
   test('denormalizes schema with extra members', () => {

--- a/src/schemas/Array.js
+++ b/src/schemas/Array.js
@@ -29,7 +29,7 @@ export const denormalize = (schema, input, unvisit) => {
       ? input
           .map((entityOrId) => {
             const [value, foundItem] = unvisit(entityOrId, schema);
-            if (value === undefined || !foundItem) {
+            if (!foundItem) {
               found = false;
             }
             return value;
@@ -56,7 +56,7 @@ export default class ArraySchema extends PolymorphicSchema {
         ? input
             .map((entityOrId) => {
               const [value, foundItem] = this.denormalizeValue(entityOrId, unvisit);
-              if (value === undefined || !foundItem) {
+              if (!foundItem) {
                 found = false;
               }
               return value;

--- a/src/schemas/Array.js
+++ b/src/schemas/Array.js
@@ -23,7 +23,21 @@ export const normalize = (schema, input, parent, key, visit, addEntity, visitedE
 
 export const denormalize = (schema, input, unvisit) => {
   schema = validateSchema(schema);
-  return input && input.map ? input.map((entityOrId) => unvisit(entityOrId, schema)) : input;
+  let found = true;
+  return [
+    input && input.map
+      ? input
+          .map((entityOrId) => {
+            const [value, foundItem] = unvisit(entityOrId, schema);
+            if (value === undefined || !foundItem) {
+              found = false;
+            }
+            return value;
+          })
+          .filter((entityOrUndefined) => entityOrUndefined)
+      : input,
+    found
+  ];
 };
 
 export default class ArraySchema extends PolymorphicSchema {
@@ -36,6 +50,20 @@ export default class ArraySchema extends PolymorphicSchema {
   }
 
   denormalize(input, unvisit) {
-    return input && input.map ? input.map((value) => this.denormalizeValue(value, unvisit)) : input;
+    let found = true;
+    return [
+      input && input.map
+        ? input
+            .map((entityOrId) => {
+              const [value, foundItem] = this.denormalizeValue(entityOrId, unvisit);
+              if (value === undefined || !foundItem) {
+                found = false;
+              }
+              return value;
+            })
+            .filter((entityOrUndefined) => entityOrUndefined)
+        : input,
+      found
+    ];
   }
 }

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -80,12 +80,17 @@ export default class EntitySchema {
       return ImmutableUtils.denormalizeImmutable(this.schema, entity, unvisit);
     }
 
+    let found = true;
     Object.keys(this.schema).forEach((key) => {
       if (entity.hasOwnProperty(key)) {
         const schema = this.schema[key];
-        entity[key] = unvisit(entity[key], schema);
+        const [value, foundItem] = unvisit(entity[key], schema);
+        entity[key] = value;
+        if (!foundItem) {
+          found = false;
+        }
       }
     });
-    return entity;
+    return [entity, found];
   }
 }

--- a/src/schemas/ImmutableUtils.js
+++ b/src/schemas/ImmutableUtils.js
@@ -29,15 +29,23 @@ export function isImmutable(object) {
  * @return {Immutable.Map|Immutable.Record}
  */
 export function denormalizeImmutable(schema, input, unvisit) {
-  return Object.keys(schema).reduce((object, key) => {
-    // Immutable maps cast keys to strings on write so we need to ensure
-    // we're accessing them using string keys.
-    const stringKey = `${key}`;
+  let found = true;
+  return [
+    Object.keys(schema).reduce((object, key) => {
+      // Immutable maps cast keys to strings on write so we need to ensure
+      // we're accessing them using string keys.
+      const stringKey = `${key}`;
 
-    if (object.has(stringKey)) {
-      return object.set(stringKey, unvisit(object.get(stringKey), schema[stringKey]));
-    } else {
-      return object;
-    }
-  }, input);
+      if (object.has(stringKey)) {
+        const [item, foundItem] = unvisit(object.get(stringKey), schema[stringKey]);
+        if (!foundItem) {
+          found = false;
+        }
+        return object.set(stringKey, item);
+      } else {
+        return object;
+      }
+    }, input),
+    found
+  ];
 }

--- a/src/schemas/Object.js
+++ b/src/schemas/Object.js
@@ -20,12 +20,17 @@ export const denormalize = (schema, input, unvisit) => {
   }
 
   const object = { ...input };
+  let found = true;
   Object.keys(schema).forEach((key) => {
     if (object[key] != null) {
-      object[key] = unvisit(object[key], schema[key]);
+      const [item, foundItem] = unvisit(object[key], schema[key]);
+      object[key] = item;
+      if (!foundItem) {
+        found = false;
+      }
     }
   });
-  return object;
+  return [object, found];
 };
 
 export default class ObjectSchema {

--- a/src/schemas/Polymorphic.js
+++ b/src/schemas/Polymorphic.js
@@ -43,7 +43,7 @@ export default class PolymorphicSchema {
   denormalizeValue(value, unvisit) {
     const schemaKey = isImmutable(value) ? value.get('schema') : value.schema;
     if (!this.isSingleSchema && !schemaKey) {
-      return value;
+      return [value, true];
     }
     const id = isImmutable(value) ? value.get('id') : value.id;
     const schema = this.isSingleSchema ? this.schema : this.schema[schemaKey];

--- a/src/schemas/Values.js
+++ b/src/schemas/Values.js
@@ -14,12 +14,20 @@ export default class ValuesSchema extends PolymorphicSchema {
   }
 
   denormalize(input, unvisit) {
-    return Object.keys(input).reduce((output, key) => {
-      const entityOrId = input[key];
-      return {
-        ...output,
-        [key]: this.denormalizeValue(entityOrId, unvisit)
-      };
-    }, {});
+    let found = true;
+    return [
+      Object.keys(input).reduce((output, key) => {
+        const entityOrId = input[key];
+        const [value, foundItem] = this.denormalizeValue(entityOrId, unvisit);
+        if (!foundItem) {
+          found = false;
+        }
+        return {
+          ...output,
+          [key]: value
+        };
+      }, {}),
+      found
+    ];
   }
 }

--- a/src/schemas/__tests__/Array.test.js
+++ b/src/schemas/__tests__/Array.test.js
@@ -111,10 +111,12 @@ describe(`${schema.Array.name} denormalization`, () => {
           2: { id: 2, name: 'Jake' }
         }
       };
-      expect(denormalize([{ data: 1 }, { data: 2 }, { data: 3 }], [{ data: cats }], entities)).toMatchSnapshot();
-      expect(
-        denormalize([{ data: 1 }, { data: 2 }, { data: 3 }], [{ data: cats }], fromJS(entities))
-      ).toMatchSnapshot();
+      let [value, foundEntities] = denormalize([{ data: 1 }, { data: 2 }, { data: 3 }], [{ data: cats }], entities);
+      expect(value).toMatchSnapshot();
+      expect(foundEntities).toBe(false);
+      [value, foundEntities] = denormalize([{ data: 1 }, { data: 2 }, { data: 3 }], [{ data: cats }], fromJS(entities));
+      expect(value).toMatchSnapshot();
+      expect(foundEntities).toBe(false);
     });
 
     test('returns the input value if is not an array', () => {

--- a/src/schemas/__tests__/Array.test.js
+++ b/src/schemas/__tests__/Array.test.js
@@ -103,6 +103,20 @@ describe(`${schema.Array.name} denormalization`, () => {
       expect(denormalize([1, 2], [cats], fromJS(entities))).toMatchSnapshot();
     });
 
+    test('denormalizes with missing entity should have false second value', () => {
+      const cats = new schema.Entity('cats');
+      const entities = {
+        cats: {
+          1: { id: 1, name: 'Milo' },
+          2: { id: 2, name: 'Jake' }
+        }
+      };
+      expect(denormalize([{ data: 1 }, { data: 2 }, { data: 3 }], [{ data: cats }], entities)).toMatchSnapshot();
+      expect(
+        denormalize([{ data: 1 }, { data: 2 }, { data: 3 }], [{ data: cats }], fromJS(entities))
+      ).toMatchSnapshot();
+    });
+
     test('returns the input value if is not an array', () => {
       const filling = new schema.Entity('fillings');
       const taco = new schema.Entity('tacos', { fillings: [filling] });
@@ -132,6 +146,19 @@ describe(`${schema.Array.name} denormalization`, () => {
       const catList = new schema.Array(cats);
       expect(denormalize([1, 2], catList, entities)).toMatchSnapshot();
       expect(denormalize([1, 2], catList, fromJS(entities))).toMatchSnapshot();
+    });
+
+    test('denormalizes with missing entity should have false second value', () => {
+      const cats = new schema.Entity('cats');
+      const entities = {
+        cats: {
+          1: { id: 1, name: 'Milo' },
+          2: { id: 2, name: 'Jake' }
+        }
+      };
+      const catList = new schema.Array(cats);
+      expect(denormalize([1, 2, 3], catList, entities)).toMatchSnapshot();
+      expect(denormalize([1, 2, 3], catList, fromJS(entities))).toMatchSnapshot();
     });
 
     test('denormalizes multiple entities', () => {

--- a/src/schemas/__tests__/Entity.test.js
+++ b/src/schemas/__tests__/Entity.test.js
@@ -284,7 +284,7 @@ describe(`${schema.Entity.name} denormalization`, () => {
       }
     };
 
-    const denormalizedReport = denormalize('123', report, entities);
+    const [denormalizedReport] = denormalize('123', report, entities);
 
     expect(denormalizedReport).toBe(denormalizedReport.draftedBy.reports[0]);
     expect(denormalizedReport.publishedBy).toBe(denormalizedReport.draftedBy);

--- a/src/schemas/__tests__/Values.test.js
+++ b/src/schemas/__tests__/Values.test.js
@@ -111,4 +111,45 @@ describe(`${schema.Values.name} denormalization`, () => {
       )
     ).toMatchSnapshot();
   });
+
+  test('denormalizes with missing entity should have false second value', () => {
+    const cat = new schema.Entity('cats');
+    const dog = new schema.Entity('dogs');
+    const valuesSchema = new schema.Values(
+      {
+        dogs: dog,
+        cats: cat
+      },
+      (entity, key) => entity.type
+    );
+
+    const entities = {
+      cats: { 1: { id: 1, type: 'cats' } },
+      dogs: { 1: { id: 1, type: 'dogs' } }
+    };
+
+    expect(
+      denormalize(
+        {
+          fido: { id: 1, schema: 'dogs' },
+          fluffy: { id: 1, schema: 'cats' },
+          prancy: { id: 5, schema: 'cats' }
+        },
+        valuesSchema,
+        entities
+      )
+    ).toMatchSnapshot();
+
+    expect(
+      denormalize(
+        {
+          fido: { id: 1, schema: 'dogs' },
+          fluffy: { id: 1, schema: 'cats' },
+          prancy: { id: 5, schema: 'cats' }
+        },
+        valuesSchema,
+        fromJS(entities)
+      )
+    ).toMatchSnapshot();
+  });
 });

--- a/src/schemas/__tests__/__snapshots__/Array.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Array.test.js.snap
@@ -164,47 +164,41 @@ Array [
 
 exports[`ArraySchema denormalization Object denormalizes with missing entity should have false second value 1`] = `
 Array [
-  Array [
-    Object {
-      "data": Object {
-        "id": 1,
-        "name": "Milo",
-      },
+  Object {
+    "data": Object {
+      "id": 1,
+      "name": "Milo",
     },
-    Object {
-      "data": Object {
-        "id": 2,
-        "name": "Jake",
-      },
+  },
+  Object {
+    "data": Object {
+      "id": 2,
+      "name": "Jake",
     },
-    Object {
-      "data": undefined,
-    },
-  ],
-  false,
+  },
+  Object {
+    "data": undefined,
+  },
 ]
 `;
 
 exports[`ArraySchema denormalization Object denormalizes with missing entity should have false second value 2`] = `
 Array [
-  Array [
-    Object {
-      "data": Immutable.Map {
-        "id": 1,
-        "name": "Milo",
-      },
+  Object {
+    "data": Immutable.Map {
+      "id": 1,
+      "name": "Milo",
     },
-    Object {
-      "data": Immutable.Map {
-        "id": 2,
-        "name": "Jake",
-      },
+  },
+  Object {
+    "data": Immutable.Map {
+      "id": 2,
+      "name": "Jake",
     },
-    Object {
-      "data": undefined,
-    },
-  ],
-  false,
+  },
+  Object {
+    "data": undefined,
+  },
 ]
 `;
 

--- a/src/schemas/__tests__/__snapshots__/Array.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Array.test.js.snap
@@ -2,122 +2,152 @@
 
 exports[`ArraySchema denormalization Class denormalizes a single entity 1`] = `
 Array [
-  Object {
-    "id": 1,
-    "name": "Milo",
-  },
-  Object {
-    "id": 2,
-    "name": "Jake",
-  },
+  Array [
+    Object {
+      "id": 1,
+      "name": "Milo",
+    },
+    Object {
+      "id": 2,
+      "name": "Jake",
+    },
+  ],
+  true,
 ]
 `;
 
 exports[`ArraySchema denormalization Class denormalizes a single entity 2`] = `
 Array [
-  Immutable.Map {
-    "id": 1,
-    "name": "Milo",
-  },
-  Immutable.Map {
-    "id": 2,
-    "name": "Jake",
-  },
+  Array [
+    Immutable.Map {
+      "id": 1,
+      "name": "Milo",
+    },
+    Immutable.Map {
+      "id": 2,
+      "name": "Jake",
+    },
+  ],
+  true,
 ]
 `;
 
 exports[`ArraySchema denormalization Class denormalizes multiple entities 1`] = `
 Array [
-  Object {
-    "id": "123",
-    "type": "cats",
-  },
-  Object {
-    "id": "123",
-    "type": "people",
-  },
-  Object {
-    "id": "789",
-  },
-  Object {
-    "id": "456",
-    "type": "cats",
-  },
+  Array [
+    Object {
+      "id": "123",
+      "type": "cats",
+    },
+    Object {
+      "id": "123",
+      "type": "people",
+    },
+    Object {
+      "id": "789",
+    },
+    Object {
+      "id": "456",
+      "type": "cats",
+    },
+  ],
+  true,
 ]
 `;
 
 exports[`ArraySchema denormalization Class denormalizes multiple entities 2`] = `
 Array [
-  Immutable.Map {
-    "id": "123",
-    "type": "cats",
-  },
-  Immutable.Map {
-    "id": "123",
-    "type": "people",
-  },
-  Object {
-    "id": "789",
-  },
-  Immutable.Map {
-    "id": "456",
-    "type": "cats",
-  },
+  Array [
+    Immutable.Map {
+      "id": "123",
+      "type": "cats",
+    },
+    Immutable.Map {
+      "id": "123",
+      "type": "people",
+    },
+    Object {
+      "id": "789",
+    },
+    Immutable.Map {
+      "id": "456",
+      "type": "cats",
+    },
+  ],
+  true,
 ]
 `;
 
 exports[`ArraySchema denormalization Class returns the input value if is not an array 1`] = `
-Object {
-  "fillings": Object {},
-  "id": "123",
-}
+Array [
+  Object {
+    "fillings": Object {},
+    "id": "123",
+  },
+  true,
+]
 `;
 
 exports[`ArraySchema denormalization Class returns the input value if is not an array 2`] = `
-Immutable.Map {
-  "id": "123",
-  "fillings": Immutable.Map {},
-}
+Array [
+  Immutable.Map {
+    "id": "123",
+    "fillings": Immutable.Map {},
+  },
+  true,
+]
 `;
 
 exports[`ArraySchema denormalization Object denormalizes a single entity 1`] = `
 Array [
-  Object {
-    "id": 1,
-    "name": "Milo",
-  },
-  Object {
-    "id": 2,
-    "name": "Jake",
-  },
+  Array [
+    Object {
+      "id": 1,
+      "name": "Milo",
+    },
+    Object {
+      "id": 2,
+      "name": "Jake",
+    },
+  ],
+  true,
 ]
 `;
 
 exports[`ArraySchema denormalization Object denormalizes a single entity 2`] = `
 Array [
-  Immutable.Map {
-    "id": 1,
-    "name": "Milo",
-  },
-  Immutable.Map {
-    "id": 2,
-    "name": "Jake",
-  },
+  Array [
+    Immutable.Map {
+      "id": 1,
+      "name": "Milo",
+    },
+    Immutable.Map {
+      "id": 2,
+      "name": "Jake",
+    },
+  ],
+  true,
 ]
 `;
 
 exports[`ArraySchema denormalization Object returns the input value if is not an array 1`] = `
-Object {
-  "fillings": null,
-  "id": "123",
-}
+Array [
+  Object {
+    "fillings": null,
+    "id": "123",
+  },
+  true,
+]
 `;
 
 exports[`ArraySchema denormalization Object returns the input value if is not an array 2`] = `
-Immutable.Map {
-  "id": "123",
-  "fillings": null,
-}
+Array [
+  Immutable.Map {
+    "id": "123",
+    "fillings": null,
+  },
+  true,
+]
 `;
 
 exports[`ArraySchema normalization Class filters out undefined and null normalized values 1`] = `

--- a/src/schemas/__tests__/__snapshots__/Array.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Array.test.js.snap
@@ -78,6 +78,38 @@ Array [
 ]
 `;
 
+exports[`ArraySchema denormalization Class denormalizes with missing entity should have false second value 1`] = `
+Array [
+  Array [
+    Object {
+      "id": 1,
+      "name": "Milo",
+    },
+    Object {
+      "id": 2,
+      "name": "Jake",
+    },
+  ],
+  false,
+]
+`;
+
+exports[`ArraySchema denormalization Class denormalizes with missing entity should have false second value 2`] = `
+Array [
+  Array [
+    Immutable.Map {
+      "id": 1,
+      "name": "Milo",
+    },
+    Immutable.Map {
+      "id": 2,
+      "name": "Jake",
+    },
+  ],
+  false,
+]
+`;
+
 exports[`ArraySchema denormalization Class returns the input value if is not an array 1`] = `
 Array [
   Object {
@@ -127,6 +159,52 @@ Array [
     },
   ],
   true,
+]
+`;
+
+exports[`ArraySchema denormalization Object denormalizes with missing entity should have false second value 1`] = `
+Array [
+  Array [
+    Object {
+      "data": Object {
+        "id": 1,
+        "name": "Milo",
+      },
+    },
+    Object {
+      "data": Object {
+        "id": 2,
+        "name": "Jake",
+      },
+    },
+    Object {
+      "data": undefined,
+    },
+  ],
+  false,
+]
+`;
+
+exports[`ArraySchema denormalization Object denormalizes with missing entity should have false second value 2`] = `
+Array [
+  Array [
+    Object {
+      "data": Immutable.Map {
+        "id": 1,
+        "name": "Milo",
+      },
+    },
+    Object {
+      "data": Immutable.Map {
+        "id": 2,
+        "name": "Jake",
+      },
+    },
+    Object {
+      "data": undefined,
+    },
+  ],
+  false,
 ]
 `;
 

--- a/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
@@ -1,210 +1,274 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EntitySchema denormalization can denormalize already partially denormalized data 1`] = `
-Object {
-  "food": Object {
+Array [
+  Object {
+    "food": Object {
+      "id": 1,
+    },
     "id": 1,
   },
-  "id": 1,
-}
+  true,
+]
 `;
 
 exports[`EntitySchema denormalization can denormalize already partially denormalized data 2`] = `
-Immutable.Map {
-  "id": 1,
-  "food": Immutable.Map {
+Array [
+  Immutable.Map {
     "id": 1,
+    "food": Immutable.Map {
+      "id": 1,
+    },
   },
-}
+  true,
+]
 `;
 
 exports[`EntitySchema denormalization denormalizes an entity 1`] = `
-Object {
-  "id": 1,
-  "type": "foo",
-}
+Array [
+  Object {
+    "id": 1,
+    "type": "foo",
+  },
+  true,
+]
 `;
 
 exports[`EntitySchema denormalization denormalizes an entity 2`] = `
-Immutable.Map {
-  "id": 1,
-  "type": "foo",
-}
+Array [
+  Immutable.Map {
+    "id": 1,
+    "type": "foo",
+  },
+  true,
+]
 `;
 
 exports[`EntitySchema denormalization denormalizes deep entities 1`] = `
-Object {
-  "food": Object {
+Array [
+  Object {
+    "food": Object {
+      "id": 1,
+    },
     "id": 1,
   },
-  "id": 1,
-}
+  true,
+]
 `;
 
 exports[`EntitySchema denormalization denormalizes deep entities 2`] = `
-Immutable.Map {
-  "id": 1,
-  "food": Immutable.Map {
+Array [
+  Immutable.Map {
     "id": 1,
+    "food": Immutable.Map {
+      "id": 1,
+    },
   },
-}
+  true,
+]
 `;
 
 exports[`EntitySchema denormalization denormalizes deep entities 3`] = `
-Object {
-  "id": 2,
-}
+Array [
+  Object {
+    "id": 2,
+  },
+  true,
+]
 `;
 
 exports[`EntitySchema denormalization denormalizes deep entities 4`] = `
-Immutable.Map {
-  "id": 2,
-}
+Array [
+  Immutable.Map {
+    "id": 2,
+  },
+  true,
+]
 `;
 
 exports[`EntitySchema denormalization denormalizes deep entities with records 1`] = `
-Immutable.Record {
-  "id": 1,
-  "food": Immutable.Record {
+Array [
+  Immutable.Record {
     "id": 1,
+    "food": Immutable.Record {
+      "id": 1,
+    },
   },
-}
+  true,
+]
 `;
 
 exports[`EntitySchema denormalization denormalizes deep entities with records 2`] = `
-Immutable.Record {
-  "id": 1,
-  "food": Immutable.Record {
+Array [
+  Immutable.Record {
     "id": 1,
+    "food": Immutable.Record {
+      "id": 1,
+    },
   },
-}
+  true,
+]
 `;
 
 exports[`EntitySchema denormalization denormalizes deep entities with records 3`] = `
-Immutable.Record {
-  "id": 2,
-  "food": null,
-}
+Array [
+  Immutable.Record {
+    "id": 2,
+    "food": null,
+  },
+  true,
+]
 `;
 
 exports[`EntitySchema denormalization denormalizes deep entities with records 4`] = `
-Immutable.Record {
-  "id": 2,
-  "food": null,
-}
+Array [
+  Immutable.Record {
+    "id": 2,
+    "food": null,
+  },
+  true,
+]
 `;
 
 exports[`EntitySchema denormalization denormalizes recursive dependencies 1`] = `
-Object {
-  "draftedBy": Object {
-    "id": "456",
-    "reports": Array [
-      [Circular],
-    ],
-    "role": "manager",
+Array [
+  Object {
+    "draftedBy": Object {
+      "id": "456",
+      "reports": Array [
+        [Circular],
+      ],
+      "role": "manager",
+    },
+    "id": "123",
+    "publishedBy": Object {
+      "id": "456",
+      "reports": Array [
+        [Circular],
+      ],
+      "role": "manager",
+    },
+    "title": "Weekly report",
   },
-  "id": "123",
-  "publishedBy": Object {
-    "id": "456",
-    "reports": Array [
-      [Circular],
-    ],
-    "role": "manager",
-  },
-  "title": "Weekly report",
-}
+  true,
+]
 `;
 
 exports[`EntitySchema denormalization denormalizes recursive dependencies 2`] = `
-Immutable.Map {
-  "id": "123",
-  "title": "Weekly report",
-  "draftedBy": Immutable.Map {
-    "id": "456",
-    "role": "manager",
-    "reports": Immutable.List [
-      Immutable.Map {
-        "id": "123",
-        "title": "Weekly report",
-        "draftedBy": "456",
-        "publishedBy": "456",
-      },
-    ],
+Array [
+  Immutable.Map {
+    "id": "123",
+    "title": "Weekly report",
+    "draftedBy": Immutable.Map {
+      "id": "456",
+      "role": "manager",
+      "reports": Immutable.List [
+        Immutable.Map {
+          "id": "123",
+          "title": "Weekly report",
+          "draftedBy": "456",
+          "publishedBy": "456",
+        },
+      ],
+    },
+    "publishedBy": Immutable.Map {
+      "id": "456",
+      "role": "manager",
+      "reports": Immutable.List [
+        Immutable.Map {
+          "id": "123",
+          "title": "Weekly report",
+          "draftedBy": "456",
+          "publishedBy": "456",
+        },
+      ],
+    },
   },
-  "publishedBy": Immutable.Map {
-    "id": "456",
-    "role": "manager",
-    "reports": Immutable.List [
-      Immutable.Map {
-        "id": "123",
-        "title": "Weekly report",
-        "draftedBy": "456",
-        "publishedBy": "456",
-      },
-    ],
-  },
-}
+  true,
+]
 `;
 
 exports[`EntitySchema denormalization denormalizes recursive dependencies 3`] = `
-Object {
-  "id": "456",
-  "reports": Array [
-    Object {
-      "draftedBy": [Circular],
-      "id": "123",
-      "publishedBy": [Circular],
-      "title": "Weekly report",
-    },
-  ],
-  "role": "manager",
-}
+Array [
+  Object {
+    "id": "456",
+    "reports": Array [
+      Object {
+        "draftedBy": [Circular],
+        "id": "123",
+        "publishedBy": [Circular],
+        "title": "Weekly report",
+      },
+    ],
+    "role": "manager",
+  },
+  true,
+]
 `;
 
 exports[`EntitySchema denormalization denormalizes recursive dependencies 4`] = `
-Immutable.Map {
-  "id": "456",
-  "role": "manager",
-  "reports": Immutable.List [
-    Immutable.Map {
-      "id": "123",
-      "title": "Weekly report",
-      "draftedBy": Immutable.Map {
-        "id": "456",
-        "role": "manager",
-        "reports": Immutable.List [
-          "123",
-        ],
+Array [
+  Immutable.Map {
+    "id": "456",
+    "role": "manager",
+    "reports": Immutable.List [
+      Immutable.Map {
+        "id": "123",
+        "title": "Weekly report",
+        "draftedBy": Immutable.Map {
+          "id": "456",
+          "role": "manager",
+          "reports": Immutable.List [
+            "123",
+          ],
+        },
+        "publishedBy": Immutable.Map {
+          "id": "456",
+          "role": "manager",
+          "reports": Immutable.List [
+            "123",
+          ],
+        },
       },
-      "publishedBy": Immutable.Map {
-        "id": "456",
-        "role": "manager",
-        "reports": Immutable.List [
-          "123",
-        ],
-      },
-    },
-  ],
-}
+    ],
+  },
+  true,
+]
 `;
 
 exports[`EntitySchema denormalization denormalizes to undefined for missing data 1`] = `
-Object {
-  "food": undefined,
-  "id": 1,
-}
+Array [
+  Object {
+    "food": undefined,
+    "id": 1,
+  },
+  false,
+]
 `;
 
 exports[`EntitySchema denormalization denormalizes to undefined for missing data 2`] = `
-Immutable.Map {
-  "id": 1,
-  "food": undefined,
-}
+Array [
+  Immutable.Map {
+    "id": 1,
+    "food": undefined,
+  },
+  false,
+]
 `;
 
-exports[`EntitySchema denormalization denormalizes to undefined for missing data 3`] = `undefined`;
+exports[`EntitySchema denormalization denormalizes to undefined for missing data 3`] = `
+Array [
+  undefined,
+  false,
+]
+`;
 
-exports[`EntitySchema denormalization denormalizes to undefined for missing data 4`] = `undefined`;
+exports[`EntitySchema denormalization denormalizes to undefined for missing data 4`] = `
+Array [
+  undefined,
+  false,
+]
+`;
 
 exports[`EntitySchema normalization idAttribute can build the entity's ID from the parent object 1`] = `
 Object {

--- a/src/schemas/__tests__/__snapshots__/Object.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Object.test.js.snap
@@ -1,84 +1,111 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ObjectSchema denormalization denormalizes an object 1`] = `
-Object {
-  "user": Object {
-    "id": 1,
-    "name": "Nacho",
+Array [
+  Object {
+    "user": Object {
+      "id": 1,
+      "name": "Nacho",
+    },
   },
-}
+  true,
+]
 `;
 
 exports[`ObjectSchema denormalization denormalizes an object 2`] = `
-Object {
-  "user": Immutable.Map {
-    "id": 1,
-    "name": "Nacho",
+Array [
+  Object {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Nacho",
+    },
   },
-}
+  true,
+]
 `;
 
 exports[`ObjectSchema denormalization denormalizes an object 3`] = `
-Immutable.Map {
-  "user": Immutable.Map {
-    "id": 1,
-    "name": "Nacho",
+Array [
+  Immutable.Map {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Nacho",
+    },
   },
-}
+  true,
+]
 `;
 
 exports[`ObjectSchema denormalization denormalizes an object that contains a property representing a an object with an id of zero 1`] = `
-Object {
-  "user": Object {
-    "id": 0,
-    "name": "Chancho",
+Array [
+  Object {
+    "user": Object {
+      "id": 0,
+      "name": "Chancho",
+    },
   },
-}
+  true,
+]
 `;
 
 exports[`ObjectSchema denormalization denormalizes an object that contains a property representing a an object with an id of zero 2`] = `
-Object {
-  "user": Immutable.Map {
-    "id": 0,
-    "name": "Chancho",
+Array [
+  Object {
+    "user": Immutable.Map {
+      "id": 0,
+      "name": "Chancho",
+    },
   },
-}
+  true,
+]
 `;
 
 exports[`ObjectSchema denormalization denormalizes an object that contains a property representing a an object with an id of zero 3`] = `
-Immutable.Map {
-  "user": Immutable.Map {
-    "id": 0,
-    "name": "Chancho",
+Array [
+  Immutable.Map {
+    "user": Immutable.Map {
+      "id": 0,
+      "name": "Chancho",
+    },
   },
-}
+  true,
+]
 `;
 
 exports[`ObjectSchema denormalization denormalizes plain object shorthand 1`] = `
-Object {
-  "user": Object {
-    "id": 1,
-    "name": "Jane",
+Array [
+  Object {
+    "user": Object {
+      "id": 1,
+      "name": "Jane",
+    },
   },
-}
+  true,
+]
 `;
 
 exports[`ObjectSchema denormalization denormalizes plain object shorthand 2`] = `
-Object {
-  "user": Immutable.Map {
-    "id": 1,
-    "name": "Jane",
+Array [
+  Object {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
   },
-}
+  true,
+]
 `;
 
 exports[`ObjectSchema denormalization denormalizes plain object shorthand 3`] = `
-Immutable.Map {
-  "user": Immutable.Map {
-    "id": 1,
-    "name": "Jane",
+Array [
+  Immutable.Map {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
   },
-}
+  true,
+]
 `;
 
 exports[`ObjectSchema normalization filters out undefined and null values 1`] = `

--- a/src/schemas/__tests__/__snapshots__/Union.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Union.test.js.snap
@@ -1,79 +1,109 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`UnionSchema denormalization denormalizes an array of multiple entities using a function to infer the schemaAttribute 1`] = `
-Object {
-  "id": 1,
-  "type": "users",
-  "username": "Janey",
-}
+Array [
+  Object {
+    "id": 1,
+    "type": "users",
+    "username": "Janey",
+  },
+  true,
+]
 `;
 
 exports[`UnionSchema denormalization denormalizes an array of multiple entities using a function to infer the schemaAttribute 2`] = `
-Immutable.Map {
-  "id": 1,
-  "username": "Janey",
-  "type": "users",
-}
+Array [
+  Immutable.Map {
+    "id": 1,
+    "username": "Janey",
+    "type": "users",
+  },
+  true,
+]
 `;
 
 exports[`UnionSchema denormalization denormalizes an array of multiple entities using a function to infer the schemaAttribute 3`] = `
-Object {
-  "groupname": "People",
-  "id": 2,
-  "type": "groups",
-}
+Array [
+  Object {
+    "groupname": "People",
+    "id": 2,
+    "type": "groups",
+  },
+  true,
+]
 `;
 
 exports[`UnionSchema denormalization denormalizes an array of multiple entities using a function to infer the schemaAttribute 4`] = `
-Immutable.Map {
-  "id": 2,
-  "groupname": "People",
-  "type": "groups",
-}
+Array [
+  Immutable.Map {
+    "id": 2,
+    "groupname": "People",
+    "type": "groups",
+  },
+  true,
+]
 `;
 
 exports[`UnionSchema denormalization denormalizes an object using string schemaAttribute 1`] = `
-Object {
-  "id": 1,
-  "type": "users",
-  "username": "Janey",
-}
+Array [
+  Object {
+    "id": 1,
+    "type": "users",
+    "username": "Janey",
+  },
+  true,
+]
 `;
 
 exports[`UnionSchema denormalization denormalizes an object using string schemaAttribute 2`] = `
-Immutable.Map {
-  "id": 1,
-  "username": "Janey",
-  "type": "users",
-}
+Array [
+  Immutable.Map {
+    "id": 1,
+    "username": "Janey",
+    "type": "users",
+  },
+  true,
+]
 `;
 
 exports[`UnionSchema denormalization denormalizes an object using string schemaAttribute 3`] = `
-Object {
-  "groupname": "People",
-  "id": 2,
-  "type": "groups",
-}
+Array [
+  Object {
+    "groupname": "People",
+    "id": 2,
+    "type": "groups",
+  },
+  true,
+]
 `;
 
 exports[`UnionSchema denormalization denormalizes an object using string schemaAttribute 4`] = `
-Immutable.Map {
-  "id": 2,
-  "groupname": "People",
-  "type": "groups",
-}
+Array [
+  Immutable.Map {
+    "id": 2,
+    "groupname": "People",
+    "type": "groups",
+  },
+  true,
+]
 `;
 
 exports[`UnionSchema denormalization returns the original value no schema is given 1`] = `
-Object {
-  "id": 1,
-}
+Array [
+  Object {
+    "id": 1,
+  },
+  true,
+]
 `;
 
 exports[`UnionSchema denormalization returns the original value no schema is given 2`] = `
-Immutable.Map {
-  "id": 1,
-}
+Array [
+  Immutable.Map {
+    "id": 1,
+  },
+  true,
+]
 `;
 
 exports[`UnionSchema normalization normalizes an array of multiple entities using a function to infer the schemaAttribute 1`] = `

--- a/src/schemas/__tests__/__snapshots__/Values.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Values.test.js.snap
@@ -1,29 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ValuesSchema denormalization denormalizes the values of an object with the given schema 1`] = `
-Object {
-  "fido": Object {
-    "id": 1,
-    "type": "dogs",
+Array [
+  Object {
+    "fido": Object {
+      "id": 1,
+      "type": "dogs",
+    },
+    "fluffy": Object {
+      "id": 1,
+      "type": "cats",
+    },
   },
-  "fluffy": Object {
-    "id": 1,
-    "type": "cats",
-  },
-}
+  true,
+]
 `;
 
 exports[`ValuesSchema denormalization denormalizes the values of an object with the given schema 2`] = `
-Object {
-  "fido": Immutable.Map {
-    "id": 1,
-    "type": "dogs",
+Array [
+  Object {
+    "fido": Immutable.Map {
+      "id": 1,
+      "type": "dogs",
+    },
+    "fluffy": Immutable.Map {
+      "id": 1,
+      "type": "cats",
+    },
   },
-  "fluffy": Immutable.Map {
-    "id": 1,
-    "type": "cats",
-  },
-}
+  true,
+]
 `;
 
 exports[`ValuesSchema normalization can use a function to determine the schema when normalizing 1`] = `

--- a/src/schemas/__tests__/__snapshots__/Values.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Values.test.js.snap
@@ -32,6 +32,40 @@ Array [
 ]
 `;
 
+exports[`ValuesSchema denormalization denormalizes with missing entity should have false second value 1`] = `
+Array [
+  Object {
+    "fido": Object {
+      "id": 1,
+      "type": "dogs",
+    },
+    "fluffy": Object {
+      "id": 1,
+      "type": "cats",
+    },
+    "prancy": undefined,
+  },
+  false,
+]
+`;
+
+exports[`ValuesSchema denormalization denormalizes with missing entity should have false second value 2`] = `
+Array [
+  Object {
+    "fido": Immutable.Map {
+      "id": 1,
+      "type": "dogs",
+    },
+    "fluffy": Immutable.Map {
+      "id": 1,
+      "type": "cats",
+    },
+    "prancy": undefined,
+  },
+  false,
+]
+`;
+
 exports[`ValuesSchema normalization can use a function to determine the schema when normalizing 1`] = `
 Object {
   "entities": Object {


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

For instance: in many cases a user can
1) visit a list view
2) then visit detail view
3) instantly see the page, without having to get the detail response - since the entities are already there

# Solution

It's useful to track whether all entities could be found. This is valuable when trying to optimistically compute a denormalized response even when the actual result fetch isn't complete.

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [x] Update relevant documentation
