### PR TITLE
[fix] 'found' should only be false when missing entities

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -92,10 +92,15 @@ const getUnvisit = (entities) => {
       return method(schema, input, unvisit);
     }
 
+    // null is considered intentional, thus always 'found' as true
+    if (input === null) {
+      return [input, true];
+    }
+
     if (schema instanceof EntitySchema) {
-      if (input === undefined || input === null) {
-        // null is intentionally not there; whereas undefined means the entity isn't available
-        return [input, input === null];
+      // unvisitEntity just can't handle undefined
+      if (input === undefined) {
+        return [input, false];
       }
       return unvisitEntity(input, schema, unvisit, getEntity, cache);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -92,11 +92,11 @@ const getUnvisit = (entities) => {
       return method(schema, input, unvisit);
     }
 
-    if (input === undefined || input === null) {
-      return [input, true];
-    }
-
     if (schema instanceof EntitySchema) {
+      if (input === undefined || input === null) {
+        // null is intentionally not there; whereas undefined means the entity isn't available
+        return [input, input === null];
+      }
       return unvisitEntity(input, schema, unvisit, getEntity, cache);
     }
 

--- a/src/schemas/Array.js
+++ b/src/schemas/Array.js
@@ -58,7 +58,7 @@ export default class ArraySchema extends PolymorphicSchema {
   denormalize(input, unvisit) {
     let found = true;
     if (input === undefined && this.schema) {
-      const [, foundItem] = this.denormalizeValue(undefined, unvisit);
+      const [, foundItem] = unvisit(undefined, this.schema);
       if (!foundItem) {
         found = false;
       }

--- a/src/schemas/Array.js
+++ b/src/schemas/Array.js
@@ -24,6 +24,12 @@ export const normalize = (schema, input, parent, key, visit, addEntity, visitedE
 export const denormalize = (schema, input, unvisit) => {
   schema = validateSchema(schema);
   let found = true;
+  if (input === undefined && schema) {
+    const [, foundItem] = unvisit(undefined, schema);
+    if (!foundItem) {
+      found = false;
+    }
+  }
   return [
     input && input.map
       ? input
@@ -51,6 +57,12 @@ export default class ArraySchema extends PolymorphicSchema {
 
   denormalize(input, unvisit) {
     let found = true;
+    if (input === undefined && this.schema) {
+      const [, foundItem] = this.denormalizeValue(undefined, unvisit);
+      if (!foundItem) {
+        found = false;
+      }
+    }
     return [
       input && input.map
         ? input

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -82,10 +82,15 @@ export default class EntitySchema {
 
     let found = true;
     Object.keys(this.schema).forEach((key) => {
+      const schema = this.schema[key];
       if (entity.hasOwnProperty(key)) {
-        const schema = this.schema[key];
         const [value, foundItem] = unvisit(entity[key], schema);
         entity[key] = value;
+        if (!foundItem) {
+          found = false;
+        }
+      } else {
+        const [, foundItem] = unvisit(undefined, schema);
         if (!foundItem) {
           found = false;
         }

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -83,17 +83,12 @@ export default class EntitySchema {
     let found = true;
     Object.keys(this.schema).forEach((key) => {
       const schema = this.schema[key];
+      const [value, foundItem] = unvisit(entity[key], schema);
+      if (!foundItem) {
+        found = false;
+      }
       if (entity.hasOwnProperty(key)) {
-        const [value, foundItem] = unvisit(entity[key], schema);
         entity[key] = value;
-        if (!foundItem) {
-          found = false;
-        }
-      } else {
-        const [, foundItem] = unvisit(undefined, schema);
-        if (!foundItem) {
-          found = false;
-        }
       }
     });
     return [entity, found];

--- a/src/schemas/ImmutableUtils.js
+++ b/src/schemas/ImmutableUtils.js
@@ -43,6 +43,10 @@ export function denormalizeImmutable(schema, input, unvisit) {
         }
         return object.set(stringKey, item);
       } else {
+        const [, foundItem] = unvisit(undefined, schema[stringKey]);
+        if (!foundItem) {
+          found = false;
+        }
         return object;
       }
     }, input),

--- a/src/schemas/ImmutableUtils.js
+++ b/src/schemas/ImmutableUtils.js
@@ -36,17 +36,13 @@ export function denormalizeImmutable(schema, input, unvisit) {
       // we're accessing them using string keys.
       const stringKey = `${key}`;
 
+      const [item, foundItem] = unvisit(object.get(stringKey), schema[stringKey]);
+      if (!foundItem) {
+        found = false;
+      }
       if (object.has(stringKey)) {
-        const [item, foundItem] = unvisit(object.get(stringKey), schema[stringKey]);
-        if (!foundItem) {
-          found = false;
-        }
         return object.set(stringKey, item);
       } else {
-        const [, foundItem] = unvisit(undefined, schema[stringKey]);
-        if (!foundItem) {
-          found = false;
-        }
         return object;
       }
     }, input),

--- a/src/schemas/Object.js
+++ b/src/schemas/Object.js
@@ -22,17 +22,12 @@ export const denormalize = (schema, input, unvisit) => {
   const object = { ...input };
   let found = true;
   Object.keys(schema).forEach((key) => {
+    const [item, foundItem] = unvisit(object[key], schema[key]);
     if (object[key] != null) {
-      const [item, foundItem] = unvisit(object[key], schema[key]);
       object[key] = item;
-      if (!foundItem) {
-        found = false;
-      }
-    } else {
-      const [, foundItem] = unvisit(undefined, schema[key]);
-      if (!foundItem) {
-        found = false;
-      }
+    }
+    if (!foundItem) {
+      found = false;
     }
   });
   return [object, found];

--- a/src/schemas/Object.js
+++ b/src/schemas/Object.js
@@ -28,6 +28,11 @@ export const denormalize = (schema, input, unvisit) => {
       if (!foundItem) {
         found = false;
       }
+    } else {
+      const [, foundItem] = unvisit(undefined, schema[key]);
+      if (!foundItem) {
+        found = false;
+      }
     }
   });
   return [object, found];

--- a/src/schemas/__tests__/Array.test.js
+++ b/src/schemas/__tests__/Array.test.js
@@ -121,7 +121,7 @@ describe(`${schema.Array.name} denormalization`, () => {
       ).toMatchSnapshot();
     });
 
-    test('denormalizes plain arrays with plain inside', () => {
+    test('denormalizes plain arrays with plain object inside', () => {
       const userSchema = new schema.Entity('user');
       const entities = {
         user: {
@@ -265,7 +265,7 @@ describe(`${schema.Array.name} denormalization`, () => {
       ).toMatchSnapshot();
     });
 
-    test('denormalizes plain arrays with plain inside', () => {
+    test('denormalizes plain arrays with plain object inside', () => {
       const userSchema = new schema.Entity('user');
       const entities = {
         user: {

--- a/src/schemas/__tests__/Array.test.js
+++ b/src/schemas/__tests__/Array.test.js
@@ -9,48 +9,6 @@ describe(`${schema.Array.name} normalization`, () => {
       expect(normalize([{ id: 1 }, { id: 2 }], [userSchema])).toMatchSnapshot();
     });
 
-    test('denormalizes plain arrays with nothing inside', () => {
-      const userSchema = new schema.Entity('user');
-      const entities = {
-        user: {
-          1: { id: 1, name: 'Jane' }
-        }
-      };
-      expect(denormalize({ user: 1 }, { user: userSchema, tacos: [] }, entities)).toMatchSnapshot();
-      expect(denormalize({ user: 1 }, { user: userSchema, tacos: [] }, fromJS(entities))).toMatchSnapshot();
-      expect(denormalize(fromJS({ user: 1 }), { user: userSchema, tacos: [] }, fromJS(entities))).toMatchSnapshot();
-
-      expect(denormalize({ user: 1, tacos: [] }, { user: userSchema, tacos: [] }, entities)).toMatchSnapshot();
-      expect(denormalize({ user: 1, tacos: [] }, { user: userSchema, tacos: [] }, fromJS(entities))).toMatchSnapshot();
-      expect(
-        denormalize(fromJS({ user: 1, tacos: [] }), { user: userSchema, tacos: [] }, fromJS(entities))
-      ).toMatchSnapshot();
-    });
-
-    test('denormalizes plain arrays with plain inside', () => {
-      const userSchema = new schema.Entity('user');
-      const entities = {
-        user: {
-          1: { id: 1, name: 'Jane' }
-        }
-      };
-      expect(denormalize({ user: 1 }, { user: userSchema, tacos: [{ next: '' }] }, entities)).toMatchSnapshot();
-      expect(denormalize({ user: 1 }, { user: userSchema, tacos: [{ next: '' }] }, fromJS(entities))).toMatchSnapshot();
-      expect(
-        denormalize(fromJS({ user: 1 }), { user: userSchema, tacos: [{ next: '' }] }, fromJS(entities))
-      ).toMatchSnapshot();
-
-      expect(
-        denormalize({ user: 1, tacos: [] }, { user: userSchema, tacos: [{ next: '' }] }, entities)
-      ).toMatchSnapshot();
-      expect(
-        denormalize({ user: 1, tacos: [] }, { user: userSchema, tacos: [{ next: '' }] }, fromJS(entities))
-      ).toMatchSnapshot();
-      expect(
-        denormalize(fromJS({ user: 1, tacos: [] }), { user: userSchema, tacos: [{ next: '' }] }, fromJS(entities))
-      ).toMatchSnapshot();
-    });
-
     test('throws an error if created with more than one schema', () => {
       const userSchema = new schema.Entity('users');
       const catSchema = new schema.Entity('cats');
@@ -145,6 +103,48 @@ describe(`${schema.Array.name} denormalization`, () => {
       expect(denormalize([1, 2], [cats], fromJS(entities))).toMatchSnapshot();
     });
 
+    test('denormalizes plain arrays with nothing inside', () => {
+      const userSchema = new schema.Entity('user');
+      const entities = {
+        user: {
+          1: { id: 1, name: 'Jane' }
+        }
+      };
+      expect(denormalize({ user: 1 }, { user: userSchema, tacos: [] }, entities)).toMatchSnapshot();
+      expect(denormalize({ user: 1 }, { user: userSchema, tacos: [] }, fromJS(entities))).toMatchSnapshot();
+      expect(denormalize(fromJS({ user: 1 }), { user: userSchema, tacos: [] }, fromJS(entities))).toMatchSnapshot();
+
+      expect(denormalize({ user: 1, tacos: [] }, { user: userSchema, tacos: [] }, entities)).toMatchSnapshot();
+      expect(denormalize({ user: 1, tacos: [] }, { user: userSchema, tacos: [] }, fromJS(entities))).toMatchSnapshot();
+      expect(
+        denormalize(fromJS({ user: 1, tacos: [] }), { user: userSchema, tacos: [] }, fromJS(entities))
+      ).toMatchSnapshot();
+    });
+
+    test('denormalizes plain arrays with plain inside', () => {
+      const userSchema = new schema.Entity('user');
+      const entities = {
+        user: {
+          1: { id: 1, name: 'Jane' }
+        }
+      };
+      expect(denormalize({ user: 1 }, { user: userSchema, tacos: [{ next: '' }] }, entities)).toMatchSnapshot();
+      expect(denormalize({ user: 1 }, { user: userSchema, tacos: [{ next: '' }] }, fromJS(entities))).toMatchSnapshot();
+      expect(
+        denormalize(fromJS({ user: 1 }), { user: userSchema, tacos: [{ next: '' }] }, fromJS(entities))
+      ).toMatchSnapshot();
+
+      expect(
+        denormalize({ user: 1, tacos: [] }, { user: userSchema, tacos: [{ next: '' }] }, entities)
+      ).toMatchSnapshot();
+      expect(
+        denormalize({ user: 1, tacos: [] }, { user: userSchema, tacos: [{ next: '' }] }, fromJS(entities))
+      ).toMatchSnapshot();
+      expect(
+        denormalize(fromJS({ user: 1, tacos: [] }), { user: userSchema, tacos: [{ next: '' }] }, fromJS(entities))
+      ).toMatchSnapshot();
+    });
+
     test('denormalizes nested in object', () => {
       const cats = new schema.Entity('cats');
       const catSchema = { results: [cats] };
@@ -237,6 +237,115 @@ describe(`${schema.Array.name} denormalization`, () => {
       const catList = new schema.Array(cats);
       expect(denormalize([1, 2], catList, entities)).toMatchSnapshot();
       expect(denormalize([1, 2], catList, fromJS(entities))).toMatchSnapshot();
+    });
+
+    test('denormalizes plain arrays with nothing inside', () => {
+      const userSchema = new schema.Entity('user');
+      const entities = {
+        user: {
+          1: { id: 1, name: 'Jane' }
+        }
+      };
+      expect(denormalize({ user: 1 }, { user: userSchema, tacos: new schema.Array() }, entities)).toMatchSnapshot();
+      expect(
+        denormalize({ user: 1 }, { user: userSchema, tacos: new schema.Array() }, fromJS(entities))
+      ).toMatchSnapshot();
+      expect(
+        denormalize(fromJS({ user: 1 }), { user: userSchema, tacos: new schema.Array() }, fromJS(entities))
+      ).toMatchSnapshot();
+
+      expect(
+        denormalize({ user: 1, tacos: [] }, { user: userSchema, tacos: new schema.Array() }, entities)
+      ).toMatchSnapshot();
+      expect(
+        denormalize({ user: 1, tacos: [] }, { user: userSchema, tacos: new schema.Array() }, fromJS(entities))
+      ).toMatchSnapshot();
+      expect(
+        denormalize(fromJS({ user: 1, tacos: [] }), { user: userSchema, tacos: new schema.Array() }, fromJS(entities))
+      ).toMatchSnapshot();
+    });
+
+    test('denormalizes plain arrays with plain inside', () => {
+      const userSchema = new schema.Entity('user');
+      const entities = {
+        user: {
+          1: { id: 1, name: 'Jane' }
+        }
+      };
+      expect(
+        denormalize({ user: 1 }, { user: userSchema, tacos: new schema.Array({ next: '' }) }, entities)
+      ).toMatchSnapshot();
+      expect(
+        denormalize({ user: 1 }, { user: userSchema, tacos: new schema.Array({ next: '' }) }, fromJS(entities))
+      ).toMatchSnapshot();
+      expect(
+        denormalize(fromJS({ user: 1 }), { user: userSchema, tacos: new schema.Array({ next: '' }) }, fromJS(entities))
+      ).toMatchSnapshot();
+
+      expect(
+        denormalize({ user: 1, tacos: [] }, { user: userSchema, tacos: new schema.Array({ next: '' }) }, entities)
+      ).toMatchSnapshot();
+      expect(
+        denormalize(
+          { user: 1, tacos: [] },
+          { user: userSchema, tacos: new schema.Array({ next: '' }) },
+          fromJS(entities)
+        )
+      ).toMatchSnapshot();
+      expect(
+        denormalize(
+          fromJS({ user: 1, tacos: [] }),
+          { user: userSchema, tacos: new schema.Array({ next: '' }) },
+          fromJS(entities)
+        )
+      ).toMatchSnapshot();
+    });
+
+    test('denormalizes nested in object', () => {
+      const cats = new schema.Entity('cats');
+      const catSchema = { results: new schema.Array(cats) };
+      const entities = {
+        cats: {
+          1: { id: 1, name: 'Milo' },
+          2: { id: 2, name: 'Jake' }
+        }
+      };
+      expect(denormalize({ results: [1, 2] }, catSchema, entities)).toMatchSnapshot();
+      expect(denormalize({ results: [1, 2] }, catSchema, fromJS(entities))).toMatchSnapshot();
+    });
+
+    test('denormalizes nested in object with primitive', () => {
+      const cats = new schema.Entity('cats');
+      const catSchema = { results: new schema.Array(cats), nextPage: '' };
+      const entities = {
+        cats: {
+          1: { id: 1, name: 'Milo' },
+          2: { id: 2, name: 'Jake' }
+        }
+      };
+      let [value, found] = denormalize({ results: [1, 2] }, catSchema, entities);
+      expect(value).toMatchSnapshot();
+      expect(found).toBe(true);
+      [value, found] = denormalize({ results: [1, 2] }, catSchema, fromJS(entities));
+      expect(value).toMatchSnapshot();
+      expect(found).toBe(true);
+    });
+
+    test('denormalizes should not be found when result array is undefined', () => {
+      const cats = new schema.Entity('cats');
+      const catSchema = { results: new schema.Array(cats) };
+      const entities = {
+        cats: {
+          1: { id: 1, name: 'Milo' },
+          2: { id: 2, name: 'Jake' }
+        }
+      };
+      let [value, found] = denormalize({ results: undefined }, catSchema, entities);
+      expect(value).toMatchSnapshot();
+      expect(found).toBe(false);
+      [value, found] = denormalize({ results: undefined }, catSchema, fromJS(entities));
+      expect(value).toMatchSnapshot();
+      expect(found).toBe(false);
     });
 
     test('denormalizes with missing entity should have false second value', () => {

--- a/src/schemas/__tests__/Object.test.js
+++ b/src/schemas/__tests__/Object.test.js
@@ -39,6 +39,22 @@ describe(`${schema.Object.name} denormalization`, () => {
     expect(denormalize(fromJS({ user: 1 }), object, fromJS(entities))).toMatchSnapshot();
   });
 
+  test('denormalizes an object with plain members', () => {
+    const userSchema = new schema.Entity('user');
+    const object = new schema.Object({
+      user: userSchema,
+      plain: ''
+    });
+    const entities = {
+      user: {
+        1: { id: 1, name: 'Nacho' }
+      }
+    };
+    expect(denormalize({ user: 1 }, object, entities)).toMatchSnapshot();
+    expect(denormalize({ user: 1 }, object, fromJS(entities))).toMatchSnapshot();
+    expect(denormalize(fromJS({ user: 1 }), object, fromJS(entities))).toMatchSnapshot();
+  });
+
   test('denormalizes plain object shorthand', () => {
     const userSchema = new schema.Entity('user');
     const entities = {
@@ -49,6 +65,12 @@ describe(`${schema.Object.name} denormalization`, () => {
     expect(denormalize({ user: 1 }, { user: userSchema, tacos: {} }, entities)).toMatchSnapshot();
     expect(denormalize({ user: 1 }, { user: userSchema, tacos: {} }, fromJS(entities))).toMatchSnapshot();
     expect(denormalize(fromJS({ user: 1 }), { user: userSchema, tacos: {} }, fromJS(entities))).toMatchSnapshot();
+
+    expect(denormalize({ user: 1, tacos: {} }, { user: userSchema, tacos: {} }, entities)).toMatchSnapshot();
+    expect(denormalize({ user: 1, tacos: {} }, { user: userSchema, tacos: {} }, fromJS(entities))).toMatchSnapshot();
+    expect(
+      denormalize(fromJS({ user: 1, tacos: {} }), { user: userSchema, tacos: {} }, fromJS(entities))
+    ).toMatchSnapshot();
   });
 
   test('denormalizes an object that contains a property representing a an object with an id of zero', () => {

--- a/src/schemas/__tests__/Object.test.js
+++ b/src/schemas/__tests__/Object.test.js
@@ -55,6 +55,29 @@ describe(`${schema.Object.name} denormalization`, () => {
     expect(denormalize(fromJS({ user: 1 }), object, fromJS(entities))).toMatchSnapshot();
   });
 
+  test('should have found = true with null member even when schema has nested entity', () => {
+    const userSchema = new schema.Entity('user');
+    const object = {
+      item: new schema.Object({
+        user: userSchema
+      })
+    };
+    const entities = {
+      user: {
+        1: { id: 1, name: 'Nacho' }
+      }
+    };
+    let [value, found] = denormalize({ item: null }, object, entities);
+    expect(value).toMatchSnapshot();
+    expect(found).toBe(true);
+    [value, found] = denormalize({ item: null }, object, fromJS(entities));
+    expect(value).toMatchSnapshot();
+    expect(found).toBe(true);
+    [value, found] = denormalize(fromJS({ item: null }), object, fromJS(entities));
+    expect(value).toMatchSnapshot();
+    expect(found).toBe(true);
+  });
+
   test('denormalizes plain object shorthand', () => {
     const userSchema = new schema.Entity('user');
     const entities = {

--- a/src/schemas/__tests__/__snapshots__/Array.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Array.test.js.snap
@@ -78,6 +78,234 @@ Array [
 ]
 `;
 
+exports[`ArraySchema denormalization Class denormalizes nested in object 1`] = `
+Array [
+  Object {
+    "results": Array [
+      Object {
+        "id": 1,
+        "name": "Milo",
+      },
+      Object {
+        "id": 2,
+        "name": "Jake",
+      },
+    ],
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Class denormalizes nested in object 2`] = `
+Array [
+  Object {
+    "results": Array [
+      Immutable.Map {
+        "id": 1,
+        "name": "Milo",
+      },
+      Immutable.Map {
+        "id": 2,
+        "name": "Jake",
+      },
+    ],
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Class denormalizes nested in object with primitive 1`] = `
+Object {
+  "results": Array [
+    Object {
+      "id": 1,
+      "name": "Milo",
+    },
+    Object {
+      "id": 2,
+      "name": "Jake",
+    },
+  ],
+}
+`;
+
+exports[`ArraySchema denormalization Class denormalizes nested in object with primitive 2`] = `
+Object {
+  "results": Array [
+    Immutable.Map {
+      "id": 1,
+      "name": "Milo",
+    },
+    Immutable.Map {
+      "id": 2,
+      "name": "Jake",
+    },
+  ],
+}
+`;
+
+exports[`ArraySchema denormalization Class denormalizes plain arrays with nothing inside 1`] = `
+Array [
+  Object {
+    "user": Object {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Class denormalizes plain arrays with nothing inside 2`] = `
+Array [
+  Object {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Class denormalizes plain arrays with nothing inside 3`] = `
+Array [
+  Immutable.Map {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Class denormalizes plain arrays with nothing inside 4`] = `
+Array [
+  Object {
+    "tacos": Array [],
+    "user": Object {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Class denormalizes plain arrays with nothing inside 5`] = `
+Array [
+  Object {
+    "tacos": Array [],
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Class denormalizes plain arrays with nothing inside 6`] = `
+Array [
+  Immutable.Map {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+    "tacos": Immutable.List [],
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Class denormalizes plain arrays with plain inside 1`] = `
+Array [
+  Object {
+    "user": Object {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Class denormalizes plain arrays with plain inside 2`] = `
+Array [
+  Object {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Class denormalizes plain arrays with plain inside 3`] = `
+Array [
+  Immutable.Map {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Class denormalizes plain arrays with plain inside 4`] = `
+Array [
+  Object {
+    "tacos": Array [],
+    "user": Object {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Class denormalizes plain arrays with plain inside 5`] = `
+Array [
+  Object {
+    "tacos": Array [],
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Class denormalizes plain arrays with plain inside 6`] = `
+Array [
+  Immutable.Map {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+    "tacos": Immutable.List [],
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Class denormalizes should not be found when result array is undefined 1`] = `
+Object {
+  "results": undefined,
+}
+`;
+
+exports[`ArraySchema denormalization Class denormalizes should not be found when result array is undefined 2`] = `
+Object {
+  "results": undefined,
+}
+`;
+
 exports[`ArraySchema denormalization Class denormalizes with missing entity should have false second value 1`] = `
 Array [
   Array [
@@ -226,6 +454,156 @@ Object {
     },
   ],
 }
+`;
+
+exports[`ArraySchema denormalization Object denormalizes plain arrays with nothing inside 1`] = `
+Array [
+  Object {
+    "user": Object {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Object denormalizes plain arrays with nothing inside 2`] = `
+Array [
+  Object {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Object denormalizes plain arrays with nothing inside 3`] = `
+Array [
+  Immutable.Map {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Object denormalizes plain arrays with nothing inside 4`] = `
+Array [
+  Object {
+    "tacos": Array [],
+    "user": Object {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Object denormalizes plain arrays with nothing inside 5`] = `
+Array [
+  Object {
+    "tacos": Array [],
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Object denormalizes plain arrays with nothing inside 6`] = `
+Array [
+  Immutable.Map {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+    "tacos": Immutable.List [],
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Object denormalizes plain arrays with plain inside 1`] = `
+Array [
+  Object {
+    "user": Object {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Object denormalizes plain arrays with plain inside 2`] = `
+Array [
+  Object {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Object denormalizes plain arrays with plain inside 3`] = `
+Array [
+  Immutable.Map {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Object denormalizes plain arrays with plain inside 4`] = `
+Array [
+  Object {
+    "tacos": Array [],
+    "user": Object {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Object denormalizes plain arrays with plain inside 5`] = `
+Array [
+  Object {
+    "tacos": Array [],
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Object denormalizes plain arrays with plain inside 6`] = `
+Array [
+  Immutable.Map {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+    "tacos": Immutable.List [],
+  },
+  true,
+]
 `;
 
 exports[`ArraySchema denormalization Object denormalizes should not be found when result array is undefined 1`] = `
@@ -571,156 +949,6 @@ Array [
     ],
     null,
   ],
-]
-`;
-
-exports[`ArraySchema normalization Object denormalizes plain arrays with nothing inside 1`] = `
-Array [
-  Object {
-    "user": Object {
-      "id": 1,
-      "name": "Jane",
-    },
-  },
-  true,
-]
-`;
-
-exports[`ArraySchema normalization Object denormalizes plain arrays with nothing inside 2`] = `
-Array [
-  Object {
-    "user": Immutable.Map {
-      "id": 1,
-      "name": "Jane",
-    },
-  },
-  true,
-]
-`;
-
-exports[`ArraySchema normalization Object denormalizes plain arrays with nothing inside 3`] = `
-Array [
-  Immutable.Map {
-    "user": Immutable.Map {
-      "id": 1,
-      "name": "Jane",
-    },
-  },
-  true,
-]
-`;
-
-exports[`ArraySchema normalization Object denormalizes plain arrays with nothing inside 4`] = `
-Array [
-  Object {
-    "tacos": Array [],
-    "user": Object {
-      "id": 1,
-      "name": "Jane",
-    },
-  },
-  true,
-]
-`;
-
-exports[`ArraySchema normalization Object denormalizes plain arrays with nothing inside 5`] = `
-Array [
-  Object {
-    "tacos": Array [],
-    "user": Immutable.Map {
-      "id": 1,
-      "name": "Jane",
-    },
-  },
-  true,
-]
-`;
-
-exports[`ArraySchema normalization Object denormalizes plain arrays with nothing inside 6`] = `
-Array [
-  Immutable.Map {
-    "user": Immutable.Map {
-      "id": 1,
-      "name": "Jane",
-    },
-    "tacos": Immutable.List [],
-  },
-  true,
-]
-`;
-
-exports[`ArraySchema normalization Object denormalizes plain arrays with plain inside 1`] = `
-Array [
-  Object {
-    "user": Object {
-      "id": 1,
-      "name": "Jane",
-    },
-  },
-  true,
-]
-`;
-
-exports[`ArraySchema normalization Object denormalizes plain arrays with plain inside 2`] = `
-Array [
-  Object {
-    "user": Immutable.Map {
-      "id": 1,
-      "name": "Jane",
-    },
-  },
-  true,
-]
-`;
-
-exports[`ArraySchema normalization Object denormalizes plain arrays with plain inside 3`] = `
-Array [
-  Immutable.Map {
-    "user": Immutable.Map {
-      "id": 1,
-      "name": "Jane",
-    },
-  },
-  true,
-]
-`;
-
-exports[`ArraySchema normalization Object denormalizes plain arrays with plain inside 4`] = `
-Array [
-  Object {
-    "tacos": Array [],
-    "user": Object {
-      "id": 1,
-      "name": "Jane",
-    },
-  },
-  true,
-]
-`;
-
-exports[`ArraySchema normalization Object denormalizes plain arrays with plain inside 5`] = `
-Array [
-  Object {
-    "tacos": Array [],
-    "user": Immutable.Map {
-      "id": 1,
-      "name": "Jane",
-    },
-  },
-  true,
-]
-`;
-
-exports[`ArraySchema normalization Object denormalizes plain arrays with plain inside 6`] = `
-Array [
-  Immutable.Map {
-    "user": Immutable.Map {
-      "id": 1,
-      "name": "Jane",
-    },
-    "tacos": Immutable.List [],
-  },
-  true,
 ]
 `;
 

--- a/src/schemas/__tests__/__snapshots__/Array.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Array.test.js.snap
@@ -219,7 +219,7 @@ Array [
 ]
 `;
 
-exports[`ArraySchema denormalization Class denormalizes plain arrays with plain inside 1`] = `
+exports[`ArraySchema denormalization Class denormalizes plain arrays with plain object inside 1`] = `
 Array [
   Object {
     "user": Object {
@@ -231,7 +231,7 @@ Array [
 ]
 `;
 
-exports[`ArraySchema denormalization Class denormalizes plain arrays with plain inside 2`] = `
+exports[`ArraySchema denormalization Class denormalizes plain arrays with plain object inside 2`] = `
 Array [
   Object {
     "user": Immutable.Map {
@@ -243,7 +243,7 @@ Array [
 ]
 `;
 
-exports[`ArraySchema denormalization Class denormalizes plain arrays with plain inside 3`] = `
+exports[`ArraySchema denormalization Class denormalizes plain arrays with plain object inside 3`] = `
 Array [
   Immutable.Map {
     "user": Immutable.Map {
@@ -255,7 +255,7 @@ Array [
 ]
 `;
 
-exports[`ArraySchema denormalization Class denormalizes plain arrays with plain inside 4`] = `
+exports[`ArraySchema denormalization Class denormalizes plain arrays with plain object inside 4`] = `
 Array [
   Object {
     "tacos": Array [],
@@ -268,7 +268,7 @@ Array [
 ]
 `;
 
-exports[`ArraySchema denormalization Class denormalizes plain arrays with plain inside 5`] = `
+exports[`ArraySchema denormalization Class denormalizes plain arrays with plain object inside 5`] = `
 Array [
   Object {
     "tacos": Array [],
@@ -281,7 +281,7 @@ Array [
 ]
 `;
 
-exports[`ArraySchema denormalization Class denormalizes plain arrays with plain inside 6`] = `
+exports[`ArraySchema denormalization Class denormalizes plain arrays with plain object inside 6`] = `
 Array [
   Immutable.Map {
     "user": Immutable.Map {
@@ -531,7 +531,7 @@ Array [
 ]
 `;
 
-exports[`ArraySchema denormalization Object denormalizes plain arrays with plain inside 1`] = `
+exports[`ArraySchema denormalization Object denormalizes plain arrays with plain object inside 1`] = `
 Array [
   Object {
     "user": Object {
@@ -543,7 +543,7 @@ Array [
 ]
 `;
 
-exports[`ArraySchema denormalization Object denormalizes plain arrays with plain inside 2`] = `
+exports[`ArraySchema denormalization Object denormalizes plain arrays with plain object inside 2`] = `
 Array [
   Object {
     "user": Immutable.Map {
@@ -555,7 +555,7 @@ Array [
 ]
 `;
 
-exports[`ArraySchema denormalization Object denormalizes plain arrays with plain inside 3`] = `
+exports[`ArraySchema denormalization Object denormalizes plain arrays with plain object inside 3`] = `
 Array [
   Immutable.Map {
     "user": Immutable.Map {
@@ -567,7 +567,7 @@ Array [
 ]
 `;
 
-exports[`ArraySchema denormalization Object denormalizes plain arrays with plain inside 4`] = `
+exports[`ArraySchema denormalization Object denormalizes plain arrays with plain object inside 4`] = `
 Array [
   Object {
     "tacos": Array [],
@@ -580,7 +580,7 @@ Array [
 ]
 `;
 
-exports[`ArraySchema denormalization Object denormalizes plain arrays with plain inside 5`] = `
+exports[`ArraySchema denormalization Object denormalizes plain arrays with plain object inside 5`] = `
 Array [
   Object {
     "tacos": Array [],
@@ -593,7 +593,7 @@ Array [
 ]
 `;
 
-exports[`ArraySchema denormalization Object denormalizes plain arrays with plain inside 6`] = `
+exports[`ArraySchema denormalization Object denormalizes plain arrays with plain object inside 6`] = `
 Array [
   Immutable.Map {
     "user": Immutable.Map {

--- a/src/schemas/__tests__/__snapshots__/Array.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Array.test.js.snap
@@ -162,6 +162,84 @@ Array [
 ]
 `;
 
+exports[`ArraySchema denormalization Object denormalizes nested in object 1`] = `
+Array [
+  Object {
+    "results": Array [
+      Object {
+        "id": 1,
+        "name": "Milo",
+      },
+      Object {
+        "id": 2,
+        "name": "Jake",
+      },
+    ],
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Object denormalizes nested in object 2`] = `
+Array [
+  Object {
+    "results": Array [
+      Immutable.Map {
+        "id": 1,
+        "name": "Milo",
+      },
+      Immutable.Map {
+        "id": 2,
+        "name": "Jake",
+      },
+    ],
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema denormalization Object denormalizes nested in object with primitive 1`] = `
+Object {
+  "results": Array [
+    Object {
+      "id": 1,
+      "name": "Milo",
+    },
+    Object {
+      "id": 2,
+      "name": "Jake",
+    },
+  ],
+}
+`;
+
+exports[`ArraySchema denormalization Object denormalizes nested in object with primitive 2`] = `
+Object {
+  "results": Array [
+    Immutable.Map {
+      "id": 1,
+      "name": "Milo",
+    },
+    Immutable.Map {
+      "id": 2,
+      "name": "Jake",
+    },
+  ],
+}
+`;
+
+exports[`ArraySchema denormalization Object denormalizes should not be found when result array is undefined 1`] = `
+Object {
+  "results": undefined,
+}
+`;
+
+exports[`ArraySchema denormalization Object denormalizes should not be found when result array is undefined 2`] = `
+Object {
+  "results": undefined,
+}
+`;
+
 exports[`ArraySchema denormalization Object denormalizes with missing entity should have false second value 1`] = `
 Array [
   Object {
@@ -493,6 +571,156 @@ Array [
     ],
     null,
   ],
+]
+`;
+
+exports[`ArraySchema normalization Object denormalizes plain arrays with nothing inside 1`] = `
+Array [
+  Object {
+    "user": Object {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema normalization Object denormalizes plain arrays with nothing inside 2`] = `
+Array [
+  Object {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema normalization Object denormalizes plain arrays with nothing inside 3`] = `
+Array [
+  Immutable.Map {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema normalization Object denormalizes plain arrays with nothing inside 4`] = `
+Array [
+  Object {
+    "tacos": Array [],
+    "user": Object {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema normalization Object denormalizes plain arrays with nothing inside 5`] = `
+Array [
+  Object {
+    "tacos": Array [],
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema normalization Object denormalizes plain arrays with nothing inside 6`] = `
+Array [
+  Immutable.Map {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+    "tacos": Immutable.List [],
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema normalization Object denormalizes plain arrays with plain inside 1`] = `
+Array [
+  Object {
+    "user": Object {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema normalization Object denormalizes plain arrays with plain inside 2`] = `
+Array [
+  Object {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema normalization Object denormalizes plain arrays with plain inside 3`] = `
+Array [
+  Immutable.Map {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema normalization Object denormalizes plain arrays with plain inside 4`] = `
+Array [
+  Object {
+    "tacos": Array [],
+    "user": Object {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema normalization Object denormalizes plain arrays with plain inside 5`] = `
+Array [
+  Object {
+    "tacos": Array [],
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ArraySchema normalization Object denormalizes plain arrays with plain inside 6`] = `
+Array [
+  Immutable.Map {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+    "tacos": Immutable.List [],
+  },
+  true,
 ]
 `;
 

--- a/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
@@ -73,7 +73,7 @@ Array [
   Object {
     "id": 2,
   },
-  true,
+  false,
 ]
 `;
 
@@ -82,7 +82,7 @@ Array [
   Immutable.Map {
     "id": 2,
   },
-  true,
+  false,
 ]
 `;
 

--- a/src/schemas/__tests__/__snapshots__/Object.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Object.test.js.snap
@@ -183,6 +183,24 @@ Array [
 ]
 `;
 
+exports[`ObjectSchema denormalization should have found = true with null member even when schema has nested entity 1`] = `
+Object {
+  "item": null,
+}
+`;
+
+exports[`ObjectSchema denormalization should have found = true with null member even when schema has nested entity 2`] = `
+Object {
+  "item": null,
+}
+`;
+
+exports[`ObjectSchema denormalization should have found = true with null member even when schema has nested entity 3`] = `
+Immutable.Map {
+  "item": null,
+}
+`;
+
 exports[`ObjectSchema normalization filters out undefined and null values 1`] = `
 Object {
   "entities": Object {

--- a/src/schemas/__tests__/__snapshots__/Object.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Object.test.js.snap
@@ -72,6 +72,42 @@ Array [
 ]
 `;
 
+exports[`ObjectSchema denormalization denormalizes an object with plain members 1`] = `
+Array [
+  Object {
+    "user": Object {
+      "id": 1,
+      "name": "Nacho",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ObjectSchema denormalization denormalizes an object with plain members 2`] = `
+Array [
+  Object {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Nacho",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ObjectSchema denormalization denormalizes an object with plain members 3`] = `
+Array [
+  Immutable.Map {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Nacho",
+    },
+  },
+  true,
+]
+`;
+
 exports[`ObjectSchema denormalization denormalizes plain object shorthand 1`] = `
 Array [
   Object {
@@ -103,6 +139,45 @@ Array [
       "id": 1,
       "name": "Jane",
     },
+  },
+  true,
+]
+`;
+
+exports[`ObjectSchema denormalization denormalizes plain object shorthand 4`] = `
+Array [
+  Object {
+    "tacos": Object {},
+    "user": Object {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ObjectSchema denormalization denormalizes plain object shorthand 5`] = `
+Array [
+  Object {
+    "tacos": Object {},
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+  },
+  true,
+]
+`;
+
+exports[`ObjectSchema denormalization denormalizes plain object shorthand 6`] = `
+Array [
+  Immutable.Map {
+    "user": Immutable.Map {
+      "id": 1,
+      "name": "Jane",
+    },
+    "tacos": Immutable.Map {},
   },
   true,
 ]


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

Sometimes results will not include a member and this is expected by the API. denormalize should only return false if there is a missing entity that is expected. Expectation is defined as it being undefined, as null means it was intentionally missing.

# Solution

Still recurse when we don't find an item, so we can find if we're missing any entities

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [x] Update relevant documentation
