### PR TITLE
[breaking] Arrays with unfound members simply exclude them

### DIFF
--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -8,9 +8,6 @@ Array [
       "type": "foo",
     },
   },
-  Object {
-    "data": undefined,
-  },
 ]
 `;
 
@@ -35,7 +32,7 @@ Array [
       "type": "foo",
     },
   ],
-  false,
+  true,
 ]
 `;
 
@@ -49,7 +46,7 @@ Array [
       },
     ],
   },
-  false,
+  true,
 ]
 `;
 
@@ -130,11 +127,7 @@ exports[`denormalize set to undefined if schema key is not in entities 1`] = `
 Array [
   Object {
     "author": undefined,
-    "comments": Array [
-      Object {
-        "user": undefined,
-      },
-    ],
+    "comments": Array [],
     "id": "123",
   },
   false,

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -219,10 +219,7 @@ describe('denormalize', () => {
         1: { id: 1, type: 'foo' }
       }
     };
-    expect(denormalize([{ data: 1 }, { data: 2 }], [{ data: mySchema }], {})[0]).toEqual([
-      { data: undefined },
-      { data: undefined }
-    ]);
+    expect(denormalize([{ data: 1 }, { data: 2 }], [{ data: mySchema }], {})[0]).toEqual([]);
     expect(denormalize([{ data: 1 }, { data: 2 }], [{ data: mySchema }], entities)[0]).toMatchSnapshot();
   });
 

--- a/src/schemas/Array.js
+++ b/src/schemas/Array.js
@@ -25,22 +25,14 @@ export const denormalize = (schema, input, unvisit) => {
   schema = validateSchema(schema);
   let found = true;
   if (input === undefined && schema) {
-    const [, foundItem] = unvisit(undefined, schema);
-    if (!foundItem) {
-      found = false;
-    }
+    [, found] = unvisit(undefined, schema);
   }
   return [
     input && input.map
       ? input
-          .map((entityOrId) => {
-            const [value, foundItem] = unvisit(entityOrId, schema);
-            if (!foundItem) {
-              found = false;
-            }
-            return value;
-          })
-          .filter((entityOrUndefined) => entityOrUndefined)
+          .map((entityOrId) => unvisit(entityOrId, schema))
+          .filter(([, foundItem]) => foundItem)
+          .map(([value]) => value)
       : input,
     found
   ];
@@ -58,22 +50,14 @@ export default class ArraySchema extends PolymorphicSchema {
   denormalize(input, unvisit) {
     let found = true;
     if (input === undefined && this.schema) {
-      const [, foundItem] = unvisit(undefined, this.schema);
-      if (!foundItem) {
-        found = false;
-      }
+      [, found] = unvisit(undefined, this.schema);
     }
     return [
       input && input.map
         ? input
-            .map((entityOrId) => {
-              const [value, foundItem] = this.denormalizeValue(entityOrId, unvisit);
-              if (!foundItem) {
-                found = false;
-              }
-              return value;
-            })
-            .filter((entityOrUndefined) => entityOrUndefined)
+            .map((entityOrId) => this.denormalizeValue(entityOrId, unvisit))
+            .filter(([, foundItem]) => foundItem)
+            .map(([value]) => value)
         : input,
       found
     ];

--- a/src/schemas/__tests__/Array.test.js
+++ b/src/schemas/__tests__/Array.test.js
@@ -192,7 +192,7 @@ describe(`${schema.Array.name} denormalization`, () => {
       expect(found).toBe(false);
     });
 
-    test('denormalizes with missing entity should have false second value', () => {
+    test('denormalizes with missing entity should have true second value', () => {
       const cats = new schema.Entity('cats');
       const entities = {
         cats: {
@@ -202,10 +202,10 @@ describe(`${schema.Array.name} denormalization`, () => {
       };
       let [value, foundEntities] = denormalize([{ data: 1 }, { data: 2 }, { data: 3 }], [{ data: cats }], entities);
       expect(value).toMatchSnapshot();
-      expect(foundEntities).toBe(false);
+      expect(foundEntities).toBe(true);
       [value, foundEntities] = denormalize([{ data: 1 }, { data: 2 }, { data: 3 }], [{ data: cats }], fromJS(entities));
       expect(value).toMatchSnapshot();
-      expect(foundEntities).toBe(false);
+      expect(foundEntities).toBe(true);
     });
 
     test('returns the input value if is not an array', () => {
@@ -348,7 +348,7 @@ describe(`${schema.Array.name} denormalization`, () => {
       expect(found).toBe(false);
     });
 
-    test('denormalizes with missing entity should have false second value', () => {
+    test('denormalizes with missing entity should have true second value', () => {
       const cats = new schema.Entity('cats');
       const entities = {
         cats: {

--- a/src/schemas/__tests__/__snapshots__/Array.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Array.test.js.snap
@@ -306,7 +306,7 @@ Object {
 }
 `;
 
-exports[`ArraySchema denormalization Class denormalizes with missing entity should have false second value 1`] = `
+exports[`ArraySchema denormalization Class denormalizes with missing entity should have true second value 1`] = `
 Array [
   Array [
     Object {
@@ -318,11 +318,11 @@ Array [
       "name": "Jake",
     },
   ],
-  false,
+  true,
 ]
 `;
 
-exports[`ArraySchema denormalization Class denormalizes with missing entity should have false second value 2`] = `
+exports[`ArraySchema denormalization Class denormalizes with missing entity should have true second value 2`] = `
 Array [
   Array [
     Immutable.Map {
@@ -334,7 +334,7 @@ Array [
       "name": "Jake",
     },
   ],
-  false,
+  true,
 ]
 `;
 
@@ -618,7 +618,7 @@ Object {
 }
 `;
 
-exports[`ArraySchema denormalization Object denormalizes with missing entity should have false second value 1`] = `
+exports[`ArraySchema denormalization Object denormalizes with missing entity should have true second value 1`] = `
 Array [
   Object {
     "data": Object {
@@ -631,14 +631,11 @@ Array [
       "id": 2,
       "name": "Jake",
     },
-  },
-  Object {
-    "data": undefined,
   },
 ]
 `;
 
-exports[`ArraySchema denormalization Object denormalizes with missing entity should have false second value 2`] = `
+exports[`ArraySchema denormalization Object denormalizes with missing entity should have true second value 2`] = `
 Array [
   Object {
     "data": Immutable.Map {
@@ -651,9 +648,6 @@ Array [
       "id": 2,
       "name": "Jake",
     },
-  },
-  Object {
-    "data": undefined,
   },
 ]
 `;


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

To support optimistic deletes sometimes only entities will be deleted. Thus in an array when an entity is not found it should not include it as a member.

# Solution

Previously this was attempting using `entityOrUndefined => entityOrUndefined` filter at the end; However this only works if there is no more nesting. The correct behavior should actually check the `found` boolean whether to filter, and actually not contribute these the found consideration. This is considered 'safe' as inferred results would have undefined for any array.

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation
