### PR TITLE
[breaking] Completely revamp typescript types to be super precise

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test:ci": "jest --ci",
     "test:coverage": "npm run test -- --coverage && cat ./coverage/lcov.info | coveralls",
     "tsc:ci": "tsc --noEmit typescript-tests/*",
-    "typecheck": "run-p flow:ci tsc:ci"
+    "typecheck": "run-p tsc:ci"
   },
   "author": "Nathaniel Tucker",
   "contributors": [
@@ -83,7 +83,7 @@
     "rollup-plugin-filesize": "^6.1.1",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-terser": "^5.0.0",
-    "typescript": "^3.4.5"
+    "typescript": "^3.6.4"
   },
   "dependencies": {
     "@babel/runtime": "^7.6.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,63 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "esnext" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "lib" /* Redirect output structure to the directory. */,
+    "rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
+    // "composite": true,                     /* Enable project compilation */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    "baseUrl": "./src" /* Base directory to resolve non-absolute module names. */,
+    "paths": {
+      "~/*": ["*"]
+    } /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
+    // "rootDirs": ["./src"],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    "allowSyntheticDefaultImports": true /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */,
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */,
+    "emitDecoratorMetadata": true /* Enables experimental support for emitting type metadata for decorators. */
+  },
+  "exclude": ["node_modules"]
+}

--- a/typescript-tests/denormalize.ts
+++ b/typescript-tests/denormalize.ts
@@ -1,0 +1,64 @@
+import { denormalize, normalize, schema, DenormalizeNullable, Normalize } from '../index';
+
+class Magic {
+  readonly a: 'first';
+  private b: boolean;
+  c: 'arg';
+}
+class Magic2 {
+  readonly a: 'second';
+  private b3: boolean;
+}
+
+const magicEntity = new schema.Entity(
+  'a',
+  {},
+  { processStrategy: (value: any, parent: any, key: string) => new Magic() }
+);
+const magicEntity2 = new schema.Entity(
+  'b',
+  {},
+  { processStrategy: (value: any, parent: any, key: string) => new Magic2() }
+);
+const unionSchema = new schema.Union(
+  {
+    user: magicEntity,
+    group: magicEntity2
+  },
+  'a'
+);
+const scheme = { thing: { data: unionSchema, members: [magicEntity] }, first: '', second: '' };
+const schemeEntity = magicEntity;
+
+const de = denormalize({}, scheme, {});
+const r = normalize({}, scheme);
+
+type A = DenormalizeNullable<typeof scheme>;
+type B = A['thing']['members'];
+type C = DenormalizeNullable<typeof schemeEntity>;
+type D = ReturnType<typeof magicEntity['_denormalizeNullable']>;
+type E = Normalize<typeof scheme>['thing']['data'];
+
+if (de[1]) {
+  const value = de[0];
+  const piece = value.thing.data.a;
+  const first: string = value.first;
+  const members = value.thing.members;
+} else {
+  const value = de[0];
+  const data = value.thing.data;
+  const members = value.thing.members;
+}
+const members2 = de[0].thing.members;
+
+const schemeValues = new schema.Values({ btc: magicEntity, eth: magicEntity2 });
+const schemeValuesSimple = new schema.Values(magicEntity);
+const [valueValues, foundValues] = denormalize({}, schemeValues, {});
+Object.keys(schemeValues).forEach((k) => {
+  const v = valueValues[k];
+  if (v && v.a === 'second') {
+    const b: Magic2 = v;
+  }
+});
+
+const [valueValuesSimple, foundValuesSimple] = denormalize({}, schemeValuesSimple, {});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5283,10 +5283,10 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
-typescript@^3.4.5:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
-  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+typescript@^3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
+  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
 
 uglify-js@^3.1.4:
   version "3.6.0"


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem



# Solution

- Introduces Denormalize and Normalize recursive type algorithms.
- Eliminates assumption that there will be only one top-level entity (thus everything being typed with that T)
- Adds more information to the schema classes
- Be more specific on normalize() and denormalize() functions.
- Simplify Schema definition to be only three Union pieces so that it is easier on memory
- Added tsconfig so all typechecks are done in strict mode

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [x] Update relevant documentation
